### PR TITLE
fixed the empty cart display

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -1,6 +1,13 @@
 class CartsController < ApplicationController
 
   def show
+    #if cart.empty?
+     # puts "******cart is empty"
+   # else 
+      #puts "*****cart has items"
+   # end
+    #puts cart.inspect
+  
   end
 
   def add_item

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -4,49 +4,66 @@
     <h1>My Cart</h1>
   </header>
 
-  <div class="panel panel-default items">
-    <table class="table table-bordered">
-      <thead>
-        <tr>
-          <th colspan="2">Product</th>
-          <th>Unit Price</th>
-          <th>Quantity</th>
-          <th>Price</th>
-        </tr>
-      </thead>
-      <tbody>
-        <% enhanced_cart.each do |item| %>
-          <%= render 'item', product: item[:product], quantity: item[:quantity].to_i %>
-        <% end %>
-      </tbody>
-      <tfoot>
-        <tr>
-          <th colspan="4">
-            TOTAL:
-          </th>
-          <th>
-            <%= cart_subtotal_cents / 100.0 %>
-          </th>
-        </tr>
-      </tfoot>
-    </table>
-  </div>
 
-  <div class="row">
-    <div class="col-xs-12">
-      <%= form_tag orders_path do %>
-        <script
-          src="https://checkout.stripe.com/checkout.js" class="stripe-button"
-          data-key="<%= Rails.configuration.stripe[:publishable_key] %>"
-          data-amount="<%= cart_subtotal_cents %>"
-          data-name="Jungle"
-          data-description="Khurram Virani's Jungle Order"
-          data-locale="auto"
-          data-email="kvirani@gmail.com"
-          data-currency="cad">
-        </script>
+
+
+  <% if enhanced_cart.empty? %>
+    <div class="alert alert-danger" role="alert">
+    Your cart is empty!
+    </div>    
+    <%= link_to 'Home', :root %>
+
+  <% else %>
+
+
+  <div class="panel panel-default items">
+  <table class="table table-bordered">
+    <thead>
+      <tr>
+        <th colspan="2">Product</th>
+        <th>Unit Price</th>
+        <th>Quantity</th>
+        <th>Price</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% enhanced_cart.each do |item| %>
+        <%= render 'item', product: item[:product], quantity: item[:quantity].to_i %>
       <% end %>
-    </div>
+    </tbody>
+    <tfoot>
+      <tr>
+        <th colspan="4">
+          TOTAL:
+        </th>
+        <th>
+          <%= cart_subtotal_cents / 100.0 %>
+        </th>
+      </tr>
+    </tfoot>
+  </table>
+</div>
+
+<div class="row">
+  <div class="col-xs-12">
+    <%= form_tag orders_path do %>
+      <script
+        src="https://checkout.stripe.com/checkout.js" class="stripe-button"
+        data-key="<%= Rails.configuration.stripe[:publishable_key] %>"
+        data-amount="<%= cart_subtotal_cents %>"
+        data-name="Jungle"
+        data-description="Khurram Virani's Jungle Order"
+        data-locale="auto"
+        data-email="kvirani@gmail.com"
+        data-currency="cad">
+      </script>
+    <% end %>
   </div>
+</div>
+
+
+
+  <% end %>
+ 
 
 </section>


### PR DESCRIPTION
When cart is empty, it shows an alert with a link to go back to home page
<img width="1002" alt="Screen Shot 2021-11-10 at 2 31 22 PM" src="https://user-images.githubusercontent.com/16887712/141180710-21657e28-2364-4090-851b-40bf593e675a.png">
